### PR TITLE
feat(usb): Add USB polling interval patch

### DIFF
--- a/patches/usb-gadget-interval-hid.patch
+++ b/patches/usb-gadget-interval-hid.patch
@@ -1,0 +1,152 @@
+diff --git a/drivers/usb/gadget/function/f_hid.c b/drivers/usb/gadget/function/f_hid.c
+index 492bb44153b3..a756d5a33a81 100644
+--- a/drivers/usb/gadget/function/f_hid.c
++++ b/drivers/usb/gadget/function/f_hid.c
+@@ -44,3 +44,4 @@ struct f_hidg {
+ 	unsigned short			report_desc_length;
+ 	char				*report_desc;
+ 	unsigned short			report_length;
++	unsigned char			interval;
+
+ 	/* recv report */
+ 	struct list_head		completed_out_req;
+@@ -103,10 +104,7 @@ static struct usb_endpoint_descriptor hidg_ss_in_ep_desc = {
+ 	.bEndpointAddress	= USB_DIR_IN,
+ 	.bmAttributes		= USB_ENDPOINT_XFER_INT,
+ 	/*.wMaxPacketSize	= DYNAMIC */
+-	.bInterval		= 4, /* FIXME: Add this field in the
+-				      * HID gadget configuration?
+-				      * (struct hidg_func_descriptor)
+-				      */
++	/*.bInterval		= DYNAMIC */
+ };
+
+ static struct usb_ss_ep_comp_descriptor hidg_ss_in_comp_desc = {
+@@ -124,10 +122,7 @@ static struct usb_endpoint_descriptor hidg_ss_out_ep_desc = {
+ 	.bEndpointAddress	= USB_DIR_OUT,
+ 	.bmAttributes		= USB_ENDPOINT_XFER_INT,
+ 	/*.wMaxPacketSize	= DYNAMIC */
+-	.bInterval		= 4, /* FIXME: Add this field in the
+-				      * HID gadget configuration?
+-				      * (struct hidg_func_descriptor)
+-				      */
++	/*.bInterval		= DYNAMIC */
+ };
+
+ static struct usb_ss_ep_comp_descriptor hidg_ss_out_comp_desc = {
+@@ -157,10 +152,7 @@ static struct usb_endpoint_descriptor hidg_hs_in_ep_desc = {
+ 	.bEndpointAddress	= USB_DIR_IN,
+ 	.bmAttributes		= USB_ENDPOINT_XFER_INT,
+ 	/*.wMaxPacketSize	= DYNAMIC */
+-	.bInterval		= 4, /* FIXME: Add this field in the
+-				      * HID gadget configuration?
+-				      * (struct hidg_func_descriptor)
+-				      */
++	/*.bInterval		= DYNAMIC */
+ };
+
+ static struct usb_endpoint_descriptor hidg_hs_out_ep_desc = {
+@@ -169,10 +161,7 @@ static struct usb_endpoint_descriptor hidg_hs_out_ep_desc = {
+ 	.bEndpointAddress	= USB_DIR_OUT,
+ 	.bmAttributes		= USB_ENDPOINT_XFER_INT,
+ 	/*.wMaxPacketSize	= DYNAMIC */
+-	.bInterval		= 4, /* FIXME: Add this field in the
+-				      * HID gadget configuration?
+-				      * (struct hidg_func_descriptor)
+-				      */
++	/*.bInterval		= DYNAMIC */
+ };
+
+ static struct usb_descriptor_header *hidg_hs_descriptors[] = {
+@@ -191,10 +180,7 @@ static struct usb_endpoint_descriptor hidg_fs_in_ep_desc = {
+ 	.bEndpointAddress	= USB_DIR_IN,
+ 	.bmAttributes		= USB_ENDPOINT_XFER_INT,
+ 	/*.wMaxPacketSize	= DYNAMIC */
+-	.bInterval		= 10, /* FIXME: Add this field in the
+-				       * HID gadget configuration?
+-				       * (struct hidg_func_descriptor)
+-				       */
++	/*.bInterval		= DYNAMIC */
+ };
+
+ static struct usb_endpoint_descriptor hidg_fs_out_ep_desc = {
+@@ -203,10 +189,7 @@ static struct usb_endpoint_descriptor hidg_fs_out_ep_desc = {
+ 	.bEndpointAddress	= USB_DIR_OUT,
+ 	.bmAttributes		= USB_ENDPOINT_XFER_INT,
+ 	/*.wMaxPacketSize	= DYNAMIC */
+-	.bInterval		= 10, /* FIXME: Add this field in the
+-				       * HID gadget configuration?
+-				       * (struct hidg_func_descriptor)
+-				       */
++	/*.bInterval		= DYNAMIC */
+ };
+
+ static struct usb_descriptor_header *hidg_fs_descriptors[] = {
+@@ -749,3 +732,4 @@ static int hidg_bind(struct usb_configuration *c, struct usb_function *f)
+ 	struct device		*device;
+ 	int			status;
+ 	dev_t			dev;
++	unsigned short interval_ms = hidg->interval;
+
+ 	/* maybe allocate device-global string IDs, and patch descriptors */
+ 	us = usb_gstrings_attach(c->cdev, ct_func_strings,
+@@ -779,16 +763,22 @@ static int hidg_bind(struct usb_configuration *c, struct usb_function *f)
+ 	hidg_interface_desc.bInterfaceSubClass = hidg->bInterfaceSubClass;
+ 	hidg_interface_desc.bInterfaceProtocol = hidg->bInterfaceProtocol;
+ 	hidg->protocol = HID_REPORT_PROTOCOL;
++	hidg_ss_in_ep_desc.bInterval = USB_MS_TO_HS_INTERVAL(interval_ms);
+ 	hidg_ss_in_ep_desc.wMaxPacketSize = cpu_to_le16(hidg->report_length);
+ 	hidg_ss_in_comp_desc.wBytesPerInterval =
+ 				cpu_to_le16(hidg->report_length);
+ 	hidg_hs_in_ep_desc.wMaxPacketSize = cpu_to_le16(hidg->report_length);
++	hidg_hs_in_ep_desc.bInterval = USB_MS_TO_HS_INTERVAL(interval_ms);
+ 	hidg_fs_in_ep_desc.wMaxPacketSize = cpu_to_le16(hidg->report_length);
++	hidg_fs_in_ep_desc.bInterval = interval_ms;
+ 	hidg_ss_out_ep_desc.wMaxPacketSize = cpu_to_le16(hidg->report_length);
+ 	hidg_ss_out_comp_desc.wBytesPerInterval =
+ 				cpu_to_le16(hidg->report_length);
++	hidg_ss_out_ep_desc.bInterval = USB_MS_TO_HS_INTERVAL(interval_ms);
+ 	hidg_hs_out_ep_desc.wMaxPacketSize = cpu_to_le16(hidg->report_length);
++	hidg_hs_out_ep_desc.bInterval = USB_MS_TO_HS_INTERVAL(interval_ms);
+ 	hidg_fs_out_ep_desc.wMaxPacketSize = cpu_to_le16(hidg->report_length);
++	hidg_fs_out_ep_desc.bInterval = interval_ms;
+ 	/*
+ 	 * We can use hidg_desc struct here but we should not relay
+ 	 * that its content won't change after returning from this function.
+@@ -924,6 +914,7 @@ CONFIGFS_ATTR(f_hid_opts_, name)
+ F_HID_OPT(subclass, 8, 255);
+ F_HID_OPT(protocol, 8, 255);
+ F_HID_OPT(report_length, 16, 65535);
++F_HID_OPT(interval, 8, 255);
+
+ static ssize_t f_hid_opts_report_desc_show(struct config_item *item, char *page)
+ {
+@@ -985,6 +976,7 @@ static struct configfs_attribute *hid_attrs[] = {
+ 	&f_hid_opts_attr_report_length,
+ 	&f_hid_opts_attr_report_desc,
+ 	&f_hid_opts_attr_dev,
++	&f_hid_opts_attr_interval,
+ 	NULL,
+ };
+
+@@ -1100,6 +1092,7 @@ static struct usb_function *hidg_alloc(struct usb_function_instance *fi)
+ 	hidg->minor = opts->minor;
+ 	hidg->bInterfaceSubClass = opts->subclass;
+ 	hidg->bInterfaceProtocol = opts->protocol;
++	hidg->interval = opts->interval;
+ 	hidg->report_length = opts->report_length;
+ 	hidg->report_desc_length = opts->report_desc_length;
+ 	if (opts->report_desc) {
+diff --git a/drivers/usb/gadget/function/u_hid.h b/drivers/usb/gadget/function/u_hid.h
+index 2f5ca4bfa7ff..9ad9e2c1f314 100644
+--- a/drivers/usb/gadget/function/u_hid.h
++++ b/drivers/usb/gadget/function/u_hid.h
+@@ -24,7 +24,7 @@ struct f_hid_opts {
+ 	unsigned short			report_desc_length;
+ 	unsigned char			*report_desc;
+ 	bool				report_desc_alloc;
+-
++	unsigned char			interval;
+ 	/*
+ 	 * Protect the data form concurrent access by read/write
+ 	 * and create symlink/remove symlink.


### PR DESCRIPTION
This patch allows userland to configure the HID USB polling interval
via ConfigFS

echo X > /sys/kernel/config/usb_gadget/gateway/functions/hid.usb0/interval