### PR TITLE
feat(serial): Set the serial close timeout to 1 second

### DIFF
--- a/patches/usb-gadget-serial-close-timeout.patch
+++ b/patches/usb-gadget-serial-close-timeout.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/usb/gadget/function/u_serial.c b/drivers/usb/gadget/function/u_serial.c
+index 38afe96c5cd2..db6922b48feb 100644
+--- a/drivers/usb/gadget/function/u_serial.c
++++ b/drivers/usb/gadget/function/u_serial.c
+@@ -129,7 +129,7 @@ static struct portmaster {
+ 	struct gs_port	*port;
+ } ports[MAX_U_SERIAL_PORTS];
+ 
+-#define GS_CLOSE_TIMEOUT		15		/* seconds */
++#define GS_CLOSE_TIMEOUT		1		/* seconds */
+ 
+ 
+ 


### PR DESCRIPTION
If an application tries to close a serial device that is not opened on
the host side it will block for 15 seconds.

Reducing this timeout to 1 second is more reasonable to avoid blocking
an application.