### PR TITLE
Build the on Travis and upload to Cloudsmith

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "linux"]
-	path = linux
-	url = https://github.com/raspberrypi/linux
 [submodule "tools"]
 	path = tools
 	url = https://github.com/raspberrypi/tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+dist: bionic
+
+git:
+  depth: false
+  submodules: true
+
+language: generic
+python:
+  - "3.7"
+
+addons:
+  apt:
+    packages:
+      - build-essential
+      - bison
+      - flex
+      - python3-pip
+      - libncurses-dev
+      - gawk
+      - openssl
+      - libssl-dev
+      - dkms
+      - libelf-dev
+      - libudev-dev
+      - libpci-dev
+      - libiberty-dev autoconf
+
+before_deploy:
+  - set -e
+  - pip3 install setuptools
+  - pip3 install cloudsmith-cli
+  - make clean
+  - make patch stage
+  - make create_zip
+
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: make push_to_cloudsmith
+    on:
+      all_branches: true
+      condition: $TRAVIS_BRANCH =~ ^(master|test\/.*)$

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,12 @@ CROSS_COMPILE := arm-linux-gnueabihf-
 KERNEL_NAME := kernel
 KERNEL_TAG := 676fd5a6f2a9b365da0e0371ef11acbb74cb69d5
 KERNEL_VERSION := 4.19.126
+KERNEL_FOLDER := linux-$(KERNEL_TAG)
+KERNEL_ZIP := $(KERNEL_TAG).zip
+
 PATH := $(PATH):$(shell pwd)/tools/arm-bcm2708/arm-linux-gnueabihf/bin
 BOARD_CONFIG := bcmrpi_defconfig
-JOBS := $(shell nproc --ignore=1)
+JOBS := $(shell nproc)
 
 BUILD ?= $(shell git describe --tags --always)
 BUILD_ARTIFACT ?= gateway_kernel_$(BUILD)
@@ -16,8 +19,7 @@ BUILD_ARTIFACT_PATH ?= $(shell pwd)/build/$(BUILD_ARTIFACT)
 SDCARD_MOUNT_BOOT ?= /media/${USERNAME}/boot
 SDCARD_MOUNT_ROOT ?= /media/${USERNAME}/rootfs
 
-ZIP_FILE_VERSION=$(KERNEL_VERSION)
-ZIP_FILE_PATH=$(PWD)/$(KERNEL_NAME)-$(ZIP_FILE_VERSION).zip
+ZIP_FILE_PREFIX=$(PWD)/$(KERNEL_NAME)-
 
 export ARCH
 export CROSS_COMPILE
@@ -26,31 +28,33 @@ export PATH
 
 all: patch kernel
 
-clean:
-	make -C linux clean
+$(KERNEL_ZIP):
+	wget -q https://github.com/raspberrypi/linux/archive/$(KERNEL_ZIP)
+
+$(KERNEL_FOLDER): $(KERNEL_ZIP)
+	unzip $(KERNEL_ZIP) >/dev/null
+
+clean: $(KERNEL_FOLDER)
+	make -C $(KERNEL_FOLDER) clean
 	rm -rf build
 
-kernel: config
+kernel: $(KERNEL_FOLDER) config
 	mkdir -p $(BUILD_ARTIFACT_PATH)
-	make -C linux -j$(JOBS) zImage modules dtbs
+	make -C $(KERNEL_FOLDER) -j$(JOBS) V=0 zImage modules dtbs
 
-patch:
-	cd linux && \
-	git fetch --all --tags && \
-	git reset --hard $(KERNEL_TAG)
-
-	cd linux && for patch in $$(find ../patches/$(KERNEL_TAG) -iname '*.patch'); do \
+patch: $(KERNEL_FOLDER)
+	cd $(KERNEL_FOLDER) && for patch in $$(find ../patches/$(KERNEL_TAG) -iname '*.patch'); do \
 		echo "apply patch $${patch}"; \
-		git apply < $$patch; \
+		patch -p1 < $$patch; \
 	done
 
-config: config.fragment
-	make -C linux $(BOARD_CONFIG)
-	cd linux && ./scripts/kconfig/merge_config.sh .config ../config.fragment
+config: $(KERNEL_FOLDER) config.fragment
+	make -C $(KERNEL_FOLDER) $(BOARD_CONFIG)
+	cd $(KERNEL_FOLDER) && ./scripts/kconfig/merge_config.sh .config ../config.fragment
 
-stage: kernel
-	cp -r linux/arch/arm/boot $(BUILD_ARTIFACT_PATH)/
-	INSTALL_MOD_PATH=$(BUILD_ARTIFACT_PATH) make -C linux modules_install
+stage: $(KERNEL_FOLDER) kernel
+	cp -r $(KERNEL_FOLDER)/arch/arm/boot $(BUILD_ARTIFACT_PATH)/
+	INSTALL_MOD_PATH=$(BUILD_ARTIFACT_PATH) make -C $(KERNEL_FOLDER) modules_install
 	rm $(BUILD_ARTIFACT_PATH)/lib/modules/*/build
 	rm $(BUILD_ARTIFACT_PATH)/lib/modules/*/source
 
@@ -62,11 +66,12 @@ copy_to_sdcard:
 	./scripts/copy_to_sdcard.sh $(BUILD_ARTIFACT_PATH)
 
 create_zip:
-	./scripts/create_zip.sh $(BUILD_ARTIFACT_PATH) $(KERNEL_NAME) $(ZIP_FILE_PATH)
+	kernel_version=$(shell make -sC $(KERNEL_FOLDER) kernelversion) && \
+	./scripts/create_zip.sh $(BUILD_ARTIFACT_PATH) $(KERNEL_NAME) $(ZIP_FILE_PREFIX)$${kernel_version}.zip
 
 push_to_cloudsmith:
-	kernel_version=$(shell make -sC linux kernelversion) \
+	kernel_version=$(shell make -sC $(KERNEL_FOLDER) kernelversion) && \
 	cloudsmith push raw proglove/gateway-cache --republish \
-	$(ZIP_FILE_PATH) \
-	--version $(ZIP_FILE_VERSION) \
+	$(ZIP_FILE_PREFIX)$${kernel_version}.zip \
+	--version $${kernel_version} \
 	--name "Linux Kernel ($(KERNEL_NAME))"

--- a/patches/raspberrypi-kernel_1.20210430-1/w25q128-erase-sector-size.patch
+++ b/patches/raspberrypi-kernel_1.20210430-1/w25q128-erase-sector-size.patch
@@ -1,3 +1,28 @@
+diff --git a/drivers/mtd/spi-nor/core.c b/drivers/mtd/spi-nor/core.c
+index ad6c79d9a7f8..2c6ea908c4f9 100644
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -2559,7 +2559,7 @@ static int spi_nor_select_erase(struct spi_nor *nor)
+ 	struct spi_nor_erase_map *map = &nor->params->erase_map;
+ 	const struct spi_nor_erase_type *erase = NULL;
+ 	struct mtd_info *mtd = &nor->mtd;
+-	u32 wanted_size = nor->info->sector_size;
++	u32 wanted_size = 32 * 1024;
+ 	int i;
+ 
+ 	/*
+@@ -2570,11 +2570,6 @@ static int spi_nor_select_erase(struct spi_nor *nor)
+ 	 * manage the SPI flash memory as uniform with a single erase sector
+ 	 * size, when possible.
+ 	 */
+-#ifdef CONFIG_MTD_SPI_NOR_USE_4K_SECTORS
+-	/* prefer "small sector" erase if possible */
+-	wanted_size = 4096u;
+-#endif
+-
+ 	if (spi_nor_has_uniform_erase(nor)) {
+ 		erase = spi_nor_select_uniform_erase(map, wanted_size);
+ 		if (!erase)
 diff --git a/drivers/mtd/spi-nor/winbond.c b/drivers/mtd/spi-nor/winbond.c
 index e5dfa786f190..6bf21a5db3dd 100644
 --- a/drivers/mtd/spi-nor/winbond.c

--- a/scripts/create_zip.sh
+++ b/scripts/create_zip.sh
@@ -1,0 +1,61 @@
+#! /usr/bin/env bash
+
+set -e
+
+SCRIPT_FOLDER=$(cd "$(dirname "$0")" && pwd)
+BUILD_FOLDER=$(mktemp -d)
+
+
+main() {
+	local linux_build_folder="$1"
+	local linux_kernel_name="$2"
+	local zip_file_output_path="$3"
+
+	if [[ -z "${linux_build_folder}" ]]; then
+		echo >&2 "No Linux kernel build folder specified"
+		return 1
+	fi
+
+	if [[ -z "${linux_kernel_name}" ]]; then
+		echo >&2 "No Linux kernel name specified"
+		return 1
+	fi
+
+	if [[ -z "${zip_file_output_path}" ]]; then
+		echo >&2 "No ZIP output file specified"
+		return 1
+	fi
+
+	echo "Linux build folder: ${linux_build_folder}"
+	echo "Kernel name: ${linux_kernel_name}"
+
+	mkdir -p "${BUILD_FOLDER}"/boot
+	mkdir -p "${BUILD_FOLDER}"/boot/overlays
+	mkdir -p "${BUILD_FOLDER}"/lib
+
+	echo "Copy lib folder"
+	cp -r --no-dereference "${linux_build_folder}"/lib/* "${BUILD_FOLDER}"/lib/
+
+	echo "Copy zImage"
+	cp "${linux_build_folder}"/boot/zImage "${BUILD_FOLDER}"/boot/"${linux_kernel_name}".img
+	echo "Copy overlays"
+	cp "${linux_build_folder}"/boot/dts/*-rpi-*.dtb "${BUILD_FOLDER}"/boot/
+	cp "${linux_build_folder}"/boot/dts/overlays/*.dtb* "${BUILD_FOLDER}"/boot/overlays/
+
+	rm -f "${zip_file_output_path}"
+	pushd "${BUILD_FOLDER}" >/dev/null
+	zip -r "${zip_file_output_path}" . >/dev/null
+	echo "Zip file: $(basename "${zip_file_output_path}")"
+	popd >/dev/null
+}
+
+
+atexit() {
+	if [[ -n "${BUILD_FOLDER}" ]]; then
+		rm -r "${BUILD_FOLDER}"
+	fi
+}
+
+
+trap atexit EXIT
+main "$@"


### PR DESCRIPTION
Sorry for the previous noise, I pushed the previous PR too early ;-)

Since we will want in the near future to stay up to date with the kernel security patches we'll have to re-build it and have it available somewhere.

Right now a human has to build it manually on a local machine which has two disadvantages
- Mistakes can be done
- Dependency on that person who has the knowledge on how to build

One other reason to have this is that our Gateway project needs this kernel image and modules to be built and available somewhere for each firmware update build, Cloudsmith is a good candidate for that.
Another approach I had was to build manually the Kernel myself and upload it to Cloudsmith but why should I do that when we can have an automated process with Travis?

I propose in this PR to build the Kernel directly on Travis and to upload the build in a zip file to Cloudsmith.
The Gateway can then download this zip and build a firmware update image with it.
Currently the build takes 30 mins and the resulting archive is around 25MB which is not too much since we will not build every day.